### PR TITLE
[FCM-DebtDay] Add support for Ruby 3 and Rails 7

### DIFF
--- a/lib/polymorphic_integer_type/activerecord_5_0_0/polymorphic_array_value_extension.rb
+++ b/lib/polymorphic_integer_type/activerecord_5_0_0/polymorphic_array_value_extension.rb
@@ -29,7 +29,7 @@ module PolymorphicIntegerType
 
           hash[key] << convert_to_id(value)
         else
-          hash[klass(value).polymorphic_name] << convert_to_id(value)
+          hash[klass(value)&.polymorphic_name] << convert_to_id(value)
         end
       end
     end

--- a/lib/polymorphic_integer_type/activerecord_5_0_0/polymorphic_array_value_extension.rb
+++ b/lib/polymorphic_integer_type/activerecord_5_0_0/polymorphic_array_value_extension.rb
@@ -29,7 +29,7 @@ module PolymorphicIntegerType
 
           hash[key] << convert_to_id(value)
         else
-          hash[klass.polymorphic_name] << convert_to_id(value)
+          hash[klass(value).polymorphic_name] << convert_to_id(value)
         end
       end
     end

--- a/lib/polymorphic_integer_type/extensions.rb
+++ b/lib/polymorphic_integer_type/extensions.rb
@@ -87,7 +87,7 @@ module PolymorphicIntegerType
         end
 
         remove_type_and_establish_mapping(name, options, scope)
-        super(name, options.delete(:scope), options, &extension)
+        super(name, options.delete(:scope), **options, &extension)
       end
 
       def has_one(name, scope = nil, **options)
@@ -97,7 +97,7 @@ module PolymorphicIntegerType
         end
 
         remove_type_and_establish_mapping(name, options, scope)
-        super(name, options.delete(:scope), options)
+        super(name, options.delete(:scope), **options)
       end
 
 

--- a/polymorphic_integer_type.gemspec
+++ b/polymorphic_integer_type.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", "< 7"
+  spec.add_dependency "activerecord"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
The [original repo](https://github.com/clio/polymorphic_integer_type) of polymorphic_integer_type doesn't appear to be actively maintained any more. There's an [open PR](https://github.com/clio/polymorphic_integer_type/pull/53) to address adding Ruby 3 and Rails 7 support. We decided to fork the original repo so that we can add this support without needing to rely on the original repo or another fork.

## Testing

Specs all pass within this repo. We also tested pointing the rma repo to this branch and verified that the deprecation warning is gone and that the behavior added by polymorphic_integer_type still works.